### PR TITLE
Increase number of matches returned.

### DIFF
--- a/web/iqdbs.rb
+++ b/web/iqdbs.rb
@@ -24,7 +24,7 @@ get "/similar" do
   ref = params["ref"]
   server = Iqdb::Server.default
   begin
-    server.download_and_query(url, ref, 1).to_json
+    server.download_and_query(url, ref, 5).to_json
   rescue Iqdb::Responses::Error => e
     JSON.generate({"error" => e.to_s})
   end


### PR DESCRIPTION
As reported in http://danbooru.donmai.us/forum_topics/9127?page=143#forum_post_123931:

Find similar for [post #2568748](http://danbooru.donmai.us/posts/2568748) doesn't return [post #2568283](http://danbooru.donmai.us/posts/2568283) as a match. I think this is because the max number of matches to return was lowered from the old value of 3 to 1.